### PR TITLE
Use PEP3127 syntax for octal literals.

### DIFF
--- a/src/foundation/python/patch-files/Python-2.6.7/setup.py
+++ b/src/foundation/python/patch-files/Python-2.6.7/setup.py
@@ -1952,8 +1952,8 @@ class PyBuildInstallLib(install_lib):
 
     def install(self):
         outfiles = install_lib.install(self)
-        self.set_file_modes(outfiles, 0644, 0755)
-        self.set_dir_modes(self.install_dir, 0755)
+        self.set_file_modes(outfiles, 0o644, 0o755)
+        self.set_dir_modes(self.install_dir, 0o755)
         return outfiles
 
     def set_file_modes(self, files, defaultMode, sharedLibMode):

--- a/src/stack/command/stack/commands/create/keys/__init__.py
+++ b/src/stack/command/stack/commands/create/keys/__init__.py
@@ -135,7 +135,7 @@ class Command(command):
 		cmd += '-out %s 1024' % key
 		status = os.system(cmd)
 		if status == 0:
-			os.chmod(key, 0400)
+			os.chmod(key, 0o400)
 
 			#
 			# output the public key

--- a/src/stack/command/stack/commands/set/host/boot/__init__.py
+++ b/src/stack/command/stack/commands/set/host/boot/__init__.py
@@ -239,7 +239,7 @@ class Command(stack.commands.set.host.command):
                         except OSError:
                                 pass
                         try:
-				os.chmod(filename, 0664)
+				os.chmod(filename, 0o664)
                         except OSError:
                                 pass
 

--- a/src/stack/images/6.7/install.img/patch-files/opt/stack/lib/anaconda_stack.py
+++ b/src/stack/images/6.7/install.img/patch-files/opt/stack/lib/anaconda_stack.py
@@ -458,7 +458,7 @@ def startSsh():
         return
 
     if not fork_orphan():
-        os.open("/var/log/lastlog", os.O_RDWR | os.O_CREAT, 0644)
+        os.open("/var/log/lastlog", os.O_RDWR | os.O_CREAT, 0o644)
         ssh_keys = {
             'rsa1':'ssh_host_key',
             'rsa':'ssh_host_rsa_key',
@@ -522,7 +522,7 @@ class Anaconda(object):
         if self.xdriver is None:
             return
         if not os.path.isdir("%s/etc/X11" %(instPath,)):
-            os.makedirs("%s/etc/X11" %(instPath,), mode=0755)
+            os.makedirs("%s/etc/X11" %(instPath,), mode=0o755)
         f = open("%s/etc/X11/xorg.conf" %(instPath,), 'w')
         f.write('Section "Device"\n\tIdentifier "Videocard0"\n\tDriver "%s"\nEndSection\n' % self.xdriver)
         f.close()
@@ -1089,7 +1089,7 @@ if __name__ == "__main__":
                # download completed, run the test
                if not os.fork():
                    # we are in the child
-                   os.chmod(testcase, 0755)
+                   os.chmod(testcase, 0o755)
                    os.execv(testcase, [testcase])
                    sys.exit(0)
                else:

--- a/src/stack/images/6.7/install.img/patch-files/usr/lib/anaconda/gui.py
+++ b/src/stack/images/6.7/install.img/patch-files/usr/lib/anaconda/gui.py
@@ -102,7 +102,7 @@ def copyScreenshots():
     destDir = "/mnt/sysimage/root/anaconda-screenshots"
     if not os.access(destDir, os.R_OK):
         try:
-            os.mkdir(destDir, 0750)
+            os.mkdir(destDir, 0o750)
         except:
             window = MessageWindow("Error Saving Screenshot", 
                                    _("An error occurred saving screenshots "

--- a/src/stack/images/6.7/install.img/patch-files/usr/lib/anaconda/packages.py
+++ b/src/stack/images/6.7/install.img/patch-files/usr/lib/anaconda/packages.py
@@ -77,7 +77,7 @@ def copyAnacondaLogs(anaconda):
         if os.access(fn, os.R_OK):
             try:
                 shutil.copyfile(fn, "%s/var/log/%s" %(anaconda.rootPath, dest))
-                os.chmod("%s/var/log/%s" %(anaconda.rootPath, dest), 0600)
+                os.chmod("%s/var/log/%s" %(anaconda.rootPath, dest), 0o600)
             except:
                 pass
 

--- a/src/stack/images/7.1503/updates.img/usr/lib64/python2.7/site-packages/pyanaconda/install.py
+++ b/src/stack/images/7.1503/updates.img/usr/lib64/python2.7/site-packages/pyanaconda/install.py
@@ -50,7 +50,7 @@ def _writeKS(ksdata):
         f.write(str(ksdata))
 
     # Make it so only root can read - could have passwords
-    os.chmod(path, 0600)
+    os.chmod(path, 0o600)
 
 def doConfiguration(storage, payload, ksdata, instClass):
     from pyanaconda.kickstart import runPostScripts

--- a/src/stack/pylib/stack/build.py
+++ b/src/stack/pylib/stack/build.py
@@ -261,7 +261,7 @@ class DistributionBuilder(Builder):
             # fix rpm permissions in the cart dirs (files get symlinked)
             
             for rpm in rpms:
-                    rpm.chmod(0644)
+                    rpm.chmod(0o644)
                     
             return rpms
     
@@ -396,7 +396,7 @@ class DistributionBuilder(Builder):
 				shutil.copy(file.getFullName(),
 					os.path.join(path, file.getName()))
 				# make sure apache can read site XML
-				file.chmod(0664)
+				file.chmod(0o664)
                                 
 	# Copy cart profiles into the distribution.
         for cart in self.carts:
@@ -511,7 +511,7 @@ class DistributionBuilder(Builder):
 		# off the CD, so it will not be needed for the remainder of
 		# the server installation.
 		#
-		os.chmod(product, 0666)
+		os.chmod(product, 0o666)
 
 	os.chdir(cwd)
 	return


### PR DESCRIPTION
The old syntax is an error in Python 3.
The new syntax was backported to Python 2.6:
https://docs.python.org/3/whatsnew/2.6.html#pep-3127-integer-literal-support-and-syntax