### PR TITLE
Allowing for virtio disks

### DIFF
--- a/src/stack/command/stack/commands/load/storage/partition/imp_load_default.py
+++ b/src/stack/command/stack/commands/load/storage/partition/imp_load_default.py
@@ -208,7 +208,7 @@ class Implementation(stack.commands.ApplianceArgumentProcessor,
 				type_dict[type_key] = device_arr
 
 		# Regexp to match Hard disk labels
-		hd_label_regexp = '[s|h]d[a-z]'
+		hd_label_regexp = '[s|h|v]d[a-z]'
 		hd_regexp = re.compile(hd_label_regexp)
 
 		# Revalidate the spreadsheet to check if pv's, volgroups have been defined


### PR DESCRIPTION
As [discussed on the forum ](https://groups.google.com/forum/#!topic/stacki/RmPHnUyk3kw) stacki is currently mis-identifying /dev/vdX (hard disk drives from the virtio driver) as a volume group.
The reason for that is a missing bit in the `hd_label_regexp` (see diff).

